### PR TITLE
fix: tile colliders were offset by half a tile size

### DIFF
--- a/src/physics/avian.rs
+++ b/src/physics/avian.rs
@@ -131,18 +131,15 @@ fn compose_tiles(
         if !filter.contains(&object.name) {
             continue;
         }
-        let object_position = Vec2 {
-            x: object.x - grid_size.x / 2.,
-            y: (grid_size.y - object.y) - grid_size.y / 2.,
-        };
+        let position = tile_offset
+            // Object position
+            + Vec2 {
+                x: object.x - grid_size.x / 2.,
+                y: (grid_size.y - object.y) - grid_size.y / 2.,
+            };
         if let Some((shape_offset, shared_shape, is_composable)) =
             get_position_and_shape(&object.shape)
         {
-            let mut position = tile_offset + object_position;
-            position += Vec2 {
-                x: grid_size.x / 2.,
-                y: grid_size.y / 2.,
-            };
             if is_composable {
                 composables.push((
                     Isometry::<Real>::new(position.into(), f32::to_radians(-object.rotation))

--- a/src/physics/rapier.rs
+++ b/src/physics/rapier.rs
@@ -128,18 +128,15 @@ fn compose_tiles(
         if !filter.contains(&object.name) {
             continue;
         }
-        let object_position = Vec2 {
-            x: object.x - grid_size.x / 2.,
-            y: (grid_size.y - object.y) - grid_size.y / 2.,
-        };
+        let position = tile_offset
+            // Object position
+            + Vec2 {
+                x: object.x - grid_size.x / 2.,
+                y: (grid_size.y - object.y) - grid_size.y / 2.,
+            };
         if let Some((shape_offset, shared_shape, is_composable)) =
             get_position_and_shape(&object.shape)
         {
-            let mut position = tile_offset + object_position;
-            position += Vec2 {
-                x: grid_size.x / 2.,
-                y: grid_size.y / 2.,
-            };
             if is_composable {
                 composables.push((
                     Isometry::<Real>::new(position.into(), f32::to_radians(-object.rotation))


### PR DESCRIPTION
If you run one of the physics examples on your branch you will notice that tile colliders are offset by half a tile.

That's because I was shifting colliders to take into account bevy_ecs_tilemap origin which is offset by half a tile (center of the [0,0] tile).

Now, with your change, everything is handled with `TilemapAnchor` and [you removed this offset](https://github.com/adrien-bon/bevy_ecs_tiled/pull/86/files#diff-82cf0a174bb4151b04e4d0eca7b6399086084f0912d7d2a138e247a50d97c02dL267) which is fine.
We just need to also remove this extra offset in avian and rapier physics backend, which is the goal of this PR.

Should be way easier now that we don't have to handle all these offset manually and everything is done via `TilemapAnchor`.